### PR TITLE
using figaro environment variables and mailcatcher

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,8 @@ source 'https://rubygems.org'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.2.0'
-# Use sqlite3 as the database for Active Record
 gem 'pg', '~> 0.17.1'
+
 # Use SCSS for stylesheets
 gem 'sass-rails', '~> 5.0'
 # Use Uglifier as compressor for JavaScript assets
@@ -32,6 +32,9 @@ gem 'country_select', '~> 2.5.1'
 gem 'annotate', '~> 2.6.10'
 
 gem 'sendgrid-ruby', '~> 1.1.6'
+
+# set environment variables in the Unix shell based in the application.yml file
+gem 'figaro'
 
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,8 @@ GEM
     execjs (2.6.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
+    figaro (1.1.1)
+      thor (~> 0.14)
     formtastic (3.1.3)
       actionpack (>= 3.2.13)
     formtastic_i18n (0.4.1)
@@ -244,6 +246,7 @@ DEPENDENCIES
   coffee-rails (~> 4.1.0)
   country_select (~> 2.5.1)
   devise (~> 3.4.1)
+  figaro
   jbuilder (~> 2.0)
   jquery-rails
   pg (~> 0.17.1)

--- a/config/application.example.yml
+++ b/config/application.example.yml
@@ -1,0 +1,16 @@
+# Sendgrid
+development:
+  SENDGRID_ADDRESS: localhost
+  SENDGRID_DOMAIN: mail.google.com
+  SENDGRID_PORT: '1025'
+  SENDGRID_API_KEY:
+  SENDGRID_USERNAME:
+  SENDGRID_PASSWORD:
+production:
+  SENDGRID_ADDRESS: smtp.sendgrid.net
+  SENDGRID_DOMAIN: mail.google.com
+  SENDGRID_PORT: '587'
+  SENDGRID_API_KEY: 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
+  SENDGRID_USERNAME: martinezcoder
+  SENDGRID_PASSWORD: Uruguay2016$
+

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,9 +29,9 @@ module Appco
     config.action_mailer.raise_delivery_errors = true
     ActionMailer::Base.delivery_method = :smtp
     ActionMailer::Base.smtp_settings = {
-      :address        => 'smtp.sendgrid.net',
-      :domain         => 'mail.google.com',
-      :port           => 587,
+      :address        => ENV['SENDGRID_ADDRESS'],
+      :domain         => ENV['SENDGRID_DOMAIN'],
+      :port           => ENV['SENDGRID_PORT'],
       :user_name      => ENV['SENDGRID_USERNAME'],
       :password       => ENV['SENDGRID_PASSWORD'],
       :authentication => :plain,


### PR DESCRIPTION
In development and test we will use http://mailcatcher.me/

With this we will avoid to use our sendgrid account in development/test environments
