### PR TITLE
mailcatcher

### DIFF
--- a/config/application.example.yml
+++ b/config/application.example.yml
@@ -1,0 +1,23 @@
+# Sendgrid
+development:
+  SENDGRID_ADDRESS: localhost
+  SENDGRID_DOMAIN: mail.google.com
+  SENDGRID_PORT: '1025'
+  SENDGRID_API_KEY:
+  SENDGRID_USERNAME:
+  SENDGRID_PASSWORD:
+test:
+  SENDGRID_ADDRESS: localhost
+  SENDGRID_DOMAIN: mail.google.com
+  SENDGRID_PORT: '1025'
+  SENDGRID_API_KEY:
+  SENDGRID_USERNAME:
+  SENDGRID_PASSWORD:
+production:
+  SENDGRID_ADDRESS: smtp.sendgrid.net
+  SENDGRID_DOMAIN: mail.google.com
+  SENDGRID_PORT: '587'
+  SENDGRID_API_KEY: production_key
+  SENDGRID_USERNAME: production_username
+  SENDGRID_PASSWORD: production_password
+

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,9 +29,9 @@ module Appco
     config.action_mailer.raise_delivery_errors = true
     ActionMailer::Base.delivery_method = :smtp
     ActionMailer::Base.smtp_settings = {
-      :address        => 'smtp.sendgrid.net',
-      :domain         => 'mail.google.com',
-      :port           => 587,
+      :address        => ENV['SENDGRID_ADDRESS'],
+      :domain         => ENV['SENDGRID_DOMAIN'],
+      :port           => ENV['SENDGRID_PORT'],
       :user_name      => ENV['SENDGRID_USERNAME'],
       :password       => ENV['SENDGRID_PASSWORD'],
       :authentication => :plain,


### PR DESCRIPTION
In development and test we will use http://mailcatcher.me/

With this we will avoid to use our sendgrid account in development/test environments
